### PR TITLE
Clean out-of-date function ``d_alloc_root''

### DIFF
--- a/hw9fs.c
+++ b/hw9fs.c
@@ -183,7 +183,7 @@ hw9fs_fill_super(struct super_block *sb, void *data, int silent)
 
 	unlock_new_inode(hw9fs_root_inode);
 	
-	if(!(sb->s_root = d_alloc_root(hw9fs_root_inode))) {
+	if(!(sb->s_root = d_make_root(hw9fs_root_inode))) {
 		iput(hw9fs_root_inode);
 		return -ENOMEM;
 	}


### PR DESCRIPTION
Howdy Agriel,
     I forked your repo for learning how to write a real filesystem. I found the following function is out-of-date. And it will give me an error when I try to compile it. here is me commit: 

``d_alloc_root'' is out of date. And it will be a compiling-time error now.
Here is the doc from kernel doc:
        d_alloc_root() is gone, along with a lot of bugs caused by code
misusing it.  Replacement: d_make_root(inode).  The difference is,
d_make_root() drops the reference to inode if dentry allocation fails.

So i change it to ``d_make_root''.

will you please merge my patch?

Thanks,
Madper Xie.
